### PR TITLE
Removing .xml from loose app files when verifying app started in logs

### DIFF
--- a/src/main/java/io/openliberty/tools/ant/AbstractTask.java
+++ b/src/main/java/io/openliberty/tools/ant/AbstractTask.java
@@ -518,6 +518,10 @@ public abstract class AbstractTask extends Task {
      * Returns file name without the extension.
      */
     protected String getFileName(String fileName) {
+        if (fileName.endsWith(".xml")) { //Handle loose app case for deploy
+            fileName = fileName.substring(0, fileName.lastIndexOf('.'));
+        }
+
         int index = fileName.lastIndexOf('.');
         return (index == -1) ? fileName : fileName.substring(0, index);
     }


### PR DESCRIPTION
Removing .xml from loose app file names in getFileName(). The deployTask was trying to find `app.war` in the start message rather than `app` and was timing out when `app.war.xml` was deployed.