### PR TITLE
Support extra environment variables in server start

### DIFF
--- a/src/main/java/io/openliberty/tools/ant/ServerTask.java
+++ b/src/main/java/io/openliberty/tools/ant/ServerTask.java
@@ -23,6 +23,7 @@ import java.net.URLClassLoader;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -83,6 +84,9 @@ public class ServerTask extends AbstractTask {
    
     // used with 'package' operation
     private String os;
+
+    private Map<String, String> environmentVariables;
+    
     private String serverRoot;
     
     @Override
@@ -108,6 +112,11 @@ public class ServerTask extends AbstractTask {
         processBuilder.directory(installDir);
         processBuilder.environment().put("JAVA_HOME", javaHome);
         processBuilder.redirectErrorStream(true);
+
+        // Set extra environment variables
+        if (environmentVariables != null) {
+            processBuilder.environment().putAll(environmentVariables);
+        }
     }
 
     @Override
@@ -640,6 +649,10 @@ public class ServerTask extends AbstractTask {
         public int getValue() {
             return val;
         }
+    }
+
+    public void setEnvironmentVariables(Map<String, String> environmentVariables) {
+        this.environmentVariables = environmentVariables;
     }
 
 }


### PR DESCRIPTION
Pass additional environment variables to the server startup ant task.

Part of https://github.com/OpenLiberty/ci.maven/issues/580
For use with https://github.com/OpenLiberty/ci.maven/pull/624 and https://github.com/OpenLiberty/ci.common/pull/91