### PR TITLE
Add Github Workflow CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,9 @@ jobs:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         os: [ubuntu-16.04, windows-latest]
         java: [ 8, 11 ]
+        WLP_VERSION: [ 20.0.0_03, 20.0.0_06 ]
         include:
+          # match up licenses to WLP versions
           - WLP_VERSION: 20.0.0_03
             WLP_LICENSE: L-CTUR-BLWMST
           - WLP_VERSION: 20.0.0_06


### PR DESCRIPTION
To speed up testing, especially with Appveyor being so slow and only limited to 1 concurrent test per account (which includes all our repos)

More build environment combinations, and all test environments (including Windows) will finish in a few minutes. No more waiting (potentially hours) for Appveyor to work through its test queue one-by-one.