### PR TITLE
Add maven cache to github CI, allow build on any pushed branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,7 +5,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: '**'
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Checkout ci.ant
       uses: actions/checkout@v2
     - name: Cache maven packages
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,5 +35,11 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Checkout ci.ant
       uses: actions/checkout@v2
+    - name: Cache maven packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Run tests with maven
       run: mvn verify -Ponline-its -D"invoker.streamLogs"=true -DwlpVersion="${{ matrix.WLP_VERSION }}" -DwlpLicense="${{ matrix.WLP_LICENSE }}" -e


### PR DESCRIPTION
Maven cache to speed up build and reduce build log size.