### PR TITLE
Update versions tested and omit workarea clean for embedded server

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,23 +11,27 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     strategy:
       fail-fast: false
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        os: [ubuntu-16.04, windows-latest]
-        java: [ 8, 11 ]
-        WLP_VERSION: [ 20.0.0_09, 20.0.0_06 ]
+        os: [ubuntu-18.04, windows-latest]
+        WLP_VERSION: [20.0.0_12, 20.0.0_09]
+        java: [11, 8]
         include:
           # match up licenses to WLP versions
+          - WLP_VERSION: 20.0.0_12
+            WLP_LICENSE: L-CTUR-BUSMFE
           - WLP_VERSION: 20.0.0_09
             WLP_LICENSE: L-CTUR-BS3K2V
-          - WLP_VERSION: 20.0.0_06
-            WLP_LICENSE: L-CTUR-BPKJTD
+        exclude:
+          - java: 8
+            WLP_VERSION: 20.0.0_09
 
+    runs-on: ${{ matrix.os }}
+    name: WL ${{ matrix.WLP_VERSION }}, Java ${{ matrix.java }}, ${{ matrix.os }}
     steps:
     - name: Setup Java ${{ matrix.java }}
       uses: joschi/setup-jdk@v2

--- a/src/it/tests/deploy-war-it/build.xml
+++ b/src/it/tests/deploy-war-it/build.xml
@@ -31,7 +31,7 @@
 
         <wlp:server ref="testServer" operation="stop" useEmbeddedServer="true" />
 
-        <wlp:clean ref="testServer" apps="true" dropins="true" />
+        <wlp:clean ref="testServer" workarea="false" apps="true" dropins="true" />
     </target>
 
 </project>


### PR DESCRIPTION
Related to #131 

Remove clean of workarea temporarily.
Update to test on 20.0.0.12.