### PR TITLE
Specify maven version for builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,17 +33,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: WL ${{ matrix.WLP_VERSION }}, Java ${{ matrix.java }}, ${{ matrix.os }}
     steps:
-    - name: Setup Java ${{ matrix.java }}
-      uses: joschi/setup-jdk@v2
-      with:
-        java-version: ${{ matrix.java }}
     - name: Checkout ci.ant
       uses: actions/checkout@v2
-    - name: Cache maven packages
-      uses: actions/cache@v2
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.2
       with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        maven-version: 3.8.1
+    - name: Setup Java ${{ matrix.java }}
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        cache: 'maven'
     - name: Run tests with maven
       run: mvn verify -Ponline-its -D"invoker.streamLogs"=true -DwlpVersion="${{ matrix.WLP_VERSION }}" -DwlpLicense="${{ matrix.WLP_LICENSE }}" -e


### PR DESCRIPTION
The maven version recently changed from 3.8.1 to 3.8.2, which introduced this bug in our builds:

https://www.mail-archive.com/issues@maven.apache.org/msg189865.html

Adding specific 3.8.1 maven version to our build yaml file.