### PR TITLE
Try to fix integration test ordering problem

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.2
       with:
-        maven-version: 3.8.1
+        maven-version: 3.8.5
     - name: Setup Java ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -85,15 +85,7 @@
                     <artifactId>maven-invoker-plugin</artifactId>
                     <version>3.1.0</version>
                     <configuration>
-                        <debug>false</debug>
-                        <goals>
-                            <goal>install</goal>
-                        </goals>
-                        <projectsDirectory>src/it</projectsDirectory>
                         <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-                        <setupIncludes>
-                            <setupInclude>${project.build.directory}/it/setup/pom.xml</setupInclude>
-                        </setupIncludes>
                     </configuration>
                     <executions>
                         <execution>
@@ -109,35 +101,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.0</version>
-                    <configuration>
-                        <excludes>
-                            <exclude>${jdk.7.excludes}</exclude>
-                        </excludes>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
     <profiles>
-        <profile>
-            <id>1.7.excludes</id>
-            <activation>
-                <jdk>1.7</jdk>
-            </activation>
-            <properties>
-                <jdk.7.excludes>**/SpringBootUtilTest.java</jdk.7.excludes>
-            </properties>
-        </profile>
-        <profile>
-            <id>1.8+excludes</id>
-            <activation>
-                <jdk>[1.8,10)</jdk>
-            </activation>
-            <properties>
-                <jdk.7.excludes>none</jdk.7.excludes>
-            </properties>
-        </profile>
         <profile>
             <id>online-its</id>
             <build>


### PR DESCRIPTION
Recent builds for Ubuntu were failing because the setup integration test was not running first like it should. I have simplified our pom.xml configuration and updated the version of Maven we are using to attempt to resolve this issue.