### PR TITLE
Use newer versions of wlp in tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,15 +17,15 @@ jobs:
       fail-fast: false
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        os: [ubuntu-20.04, windows-latest]
-        WLP_VERSION: [22.0.0_03, 21.0.0_12]
-        java: [11, 8]
+        os: [ubuntu-latest, windows-latest]
+        WLP_VERSION: [22.0.0_06, 22.0.0_09]
+        java: [17, 11, 8]
         include:
           # match up licenses to WLP versions
-          - WLP_VERSION: 22.0.0_03
-            WLP_LICENSE: L-CTUR-CBPK8P
-          - WLP_VERSION: 21.0.0_12
-            WLP_LICENSE: L-CTUR-C87LQV
+          - WLP_VERSION: 22.0.0_09
+            WLP_LICENSE: L-CTUR-CGSNU9
+          - WLP_VERSION: 22.0.0_06
+            WLP_LICENSE: L-CTUR-CDXJ6X
 
     runs-on: ${{ matrix.os }}
     name: WL ${{ matrix.WLP_VERSION }}, Java ${{ matrix.java }}, ${{ matrix.os }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,5 +42,9 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
         cache: 'maven'
-    - name: Run tests with maven
+    - name: Run tests with maven for ubuntu
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: mvn verify -Ponline-its -D"invoker.streamLogs"=true -DwlpVersion="${{ matrix.WLP_VERSION }}" -DwlpLicense="${{ matrix.WLP_LICENSE }}" -e
+    - name: Run tests with maven for windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: mvn verify -Pwindows-online-its -D"invoker.streamLogs"=true -DwlpVersion="${{ matrix.WLP_VERSION }}" -DwlpLicense="${{ matrix.WLP_LICENSE }}" -e

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,33 @@
                             </properties>
                             <profiles>
                                 <profile>online-test</profile>
+                                <profile>online-test-unix</profile>
+                            </profiles>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>windows-online-its</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <configuration>
+                            <properties>
+                                <wlpVersion>${wlpVersion}</wlpVersion>
+                                <wlpLicense>${wlpLicense}</wlpLicense>
+                            </properties>
+                            <profiles>
+                                <profile>online-test</profile>
+                                <profile>online-test-windows</profile>
                             </profiles>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -83,7 +83,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.3.0</version>
                     <configuration>
                         <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                     </configuration>
@@ -100,7 +100,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>3.0.0-M7</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/it/setup/test-war/pom.xml
+++ b/src/it/setup/test-war/pom.xml
@@ -29,7 +29,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>

--- a/src/it/tests/basic-it/pom.xml
+++ b/src/it/tests/basic-it/pom.xml
@@ -57,6 +57,47 @@
             </build>
         </profile>
         <profile>
+            <id>online-test-windows</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\windows\build.xml" target="installServer" >
+                                            <property name="wlp.license" value="${wlpLicense}" />
+                                            <property name="wlp.version" value="${wlpVersion}" />
+                                        </ant>
+                                        <ant dir="${basedir}" antfile="${basedir}\windows\build.xml" target="deploy" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>undeploy</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\windows\build.xml" target="undeploy" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>offline-test</id>
             <build>
                 <plugins>

--- a/src/it/tests/basic-it/windows/build.xml
+++ b/src/it/tests/basic-it/windows/build.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<project xmlns:wlp="antlib:io.openliberty.tools.ant" name="net.wasdev.wlp.ant.it">
+
+    <path id="liberty-ant-tasks.classpath">
+        <fileset dir="${basedir}/../../../../target" includes="liberty-ant-tasks-*.jar" />
+    </path>
+    <typedef resource="io/openliberty/tools/ant/antlib.xml" uri="antlib:io.openliberty.tools.ant" classpathref="liberty-ant-tasks.classpath" />
+
+    <property name="target.dir" value="${basedir}/target" />
+
+    <!-- Defining server configuration -->
+    <property name="wlp.install.dir" value="${target.dir}/wlp" />
+    <property name="wlp.usr.dir" value="${target.dir}/wlp_usr" />
+    <property name="wlp.output.dir" value="${target.dir}/wlp_output" />
+    <property name="servername" value="basic" />
+
+    <property name="serverConfig" value="${basedir}/src/test/resources/server.xml" />
+    <property name="bootProp" value="${basedir}/src/test/resources/bootstrap.properties" />
+
+    <target name="installServer">
+        <wlp:install-liberty licenseCode="${wlp.license}" version="${wlp.version}" basedir="${target.dir}" />
+    </target>
+
+    <target name="createServer">
+        <delete dir="${wlp.usr.dir}" />
+        <delete dir="${wlp.output.dir}" />
+        <mkdir dir="${wlp.usr.dir}" />
+        <mkdir dir="${wlp.output.dir}" />
+
+        <wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" operation="status" />
+
+        <wlp:server operation="create" ref="testServer" />
+
+        <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
+        <!-- install the same feature twice - should not cause an error -->
+        <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
+        
+        <!-- install features in nested elements -->
+        <wlp:install-feature ref="testServer" acceptLicense="true">
+            <!-- install the same feature again - should not cause an error -->
+            <feature>mongodb-2.0</feature>
+            <feature>oauth-2.0</feature>
+        </wlp:install-feature>
+
+        <copy overwrite="true" file="${serverConfig}" toFile="${wlp.usr.dir}/servers/${servername}/server.xml" />
+        <copy file="${bootProp}" toFile="${wlp.usr.dir}/servers/${servername}/bootstrap.properties" />
+        
+        <!-- install the features from the server.xml file that are not installed (openid-2-0) -->
+        <wlp:install-feature ref="testServer" acceptLicense="true" />
+    </target>
+
+    <target name="deploy" depends="createServer">
+
+        <wlp:server ref="testServer" operation="start" />
+
+        <wlp:deploy ref="testServer">
+            <fileset dir="${basedir}/../../setup/test-war/target">
+                <include name="*.war" />
+            </fileset>
+        </wlp:deploy>
+        <wlp:deploy ref="testServer" file="${basedir}/../../setup/test-eba/target/test-eba.eba" timeout="40000" deployName="my-test-eba.eba"/>
+    </target>
+
+    <target name="undeploy">
+
+        <wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" operation="status" />
+
+        <wlp:undeploy ref="testServer" file="test-war.war" timeout="50000" />
+        <wlp:undeploy ref="testServer" file="my-test-eba.eba" timeout="60000" />
+
+        <wlp:server ref="testServer" operation="stop" />
+        
+        <wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.zip" />
+    	<wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.os.zip" include="minify" os="OS/400,-z/OS"/>
+        <wlp:clean ref="testServer" apps="true" dropins="true" />
+    </target>
+
+</project>

--- a/src/it/tests/deploy-eba-it/pom.xml
+++ b/src/it/tests/deploy-eba-it/pom.xml
@@ -53,6 +53,43 @@
             </build>
         </profile>
         <profile>
+            <id>online-test-windows</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\windows\build.xml" target="deploy" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>undeploy</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\windows\build.xml" target="undeploy" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>offline-test</id>
             <build>
                 <plugins>

--- a/src/it/tests/deploy-eba-it/windows/build.xml
+++ b/src/it/tests/deploy-eba-it/windows/build.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<project xmlns:wlp="antlib:io.openliberty.tools.ant" name="net.wasdev.wlp.ant.it">
+
+    <path id="liberty-ant-tasks.classpath">
+        <fileset dir="${basedir}/../../../../target" includes="liberty-ant-tasks-*.jar" />
+    </path>
+    <typedef resource="io/openliberty/tools/ant/antlib.xml" uri="antlib:io.openliberty.tools.ant" classpathref="liberty-ant-tasks.classpath" />
+
+    <property name="target.dir" value="${basedir}/../install-server-it/target" />
+
+    <!-- Defining server configuration -->
+    <property name="wlp.install.dir" value="${target.dir}/wlp" />
+    <property name="wlp.usr.dir" value="${target.dir}/wlp_usr" />
+    <property name="wlp.output.dir" value="${target.dir}/wlp_output" />
+    <property name="servername" value="deploy.eba" />
+
+    <property name="serverConfig" value="${basedir}/src/test/resources/server.xml" />
+
+    <target name="deploy" depends="installFeatures">
+    	<wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" operation="status" />
+        
+        <copy overwrite="true" file="${serverConfig}" toFile="${wlp.usr.dir}/servers/${servername}/server.xml" />
+
+        <wlp:server ref="testServer" operation="start" />
+
+    	<wlp:deploy ref="testServer" file="${basedir}/../../setup/test-eba/target/test-eba.eba" deployName="my-test-eba.eba" timeout="40000" />
+    </target>
+
+    <target name="undeploy">
+    	<wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" operation="status" />
+
+        <wlp:undeploy ref="testServer" file="my-test-eba.eba" timeout="60000" />
+
+        <wlp:server ref="testServer" operation="stop" />
+
+        <wlp:clean ref="testServer" apps="true" dropins="true" />
+    	
+    </target>
+	
+    <target name="installFeatures">
+		<wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" operation="status" />
+
+        <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
+
+		<wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
+		        
+        <wlp:install-feature ref="testServer" acceptLicense="true">
+		    <feature>oauth-2.0</feature>
+        	<feature>wab-1.0</feature>
+        	<feature>openid-2.0</feature>
+        </wlp:install-feature>
+    </target>
+
+</project>

--- a/src/it/tests/install-features-it/pom.xml
+++ b/src/it/tests/install-features-it/pom.xml
@@ -41,6 +41,31 @@
             </build>
         </profile>
         <profile>
+            <id>online-test-windows</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-features</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\windows\build.xml" target="installFeatures" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>offline-test</id>
             <build>
                 <plugins>

--- a/src/it/tests/install-features-it/windows/build.xml
+++ b/src/it/tests/install-features-it/windows/build.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<project xmlns:wlp="antlib:io.openliberty.tools.ant" name="net.wasdev.wlp.ant.it">
+
+    <path id="liberty-ant-tasks.classpath">
+        <fileset dir="${basedir}/../../../../target" includes="liberty-ant-tasks-*.jar" />
+    </path>
+    <typedef resource="io/openliberty/tools/ant/antlib.xml" uri="antlib:io.openliberty.tools.ant" classpathref="liberty-ant-tasks.classpath" />
+
+    <property name="target.dir" value="${basedir}/../install-server-it/target" />
+
+    <!-- Defining server configuration -->
+    <property name="wlp.install.dir" value="${target.dir}/wlp" />
+    <property name="wlp.usr.dir" value="${target.dir}/wlp_usr" />
+    <property name="wlp.output.dir" value="${target.dir}/wlp_output" />
+    <property name="servername" value="install.features" />
+
+    <target name="installFeatures">
+        <wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" operation="create" />
+
+    	<wlp:install-feature ref="testServer" acceptLicense="true" name="oauth-2.0" />
+    	
+        <wlp:install-feature ref="testServer" acceptLicense="true" name="wab-1.0,openid-2.0" />
+
+    	<wlp:install-feature ref="testServer" acceptLicense="true">
+            <feature>mongodb-2.0</feature>
+        </wlp:install-feature>
+    	
+    </target>
+
+</project>

--- a/src/it/tests/pom.xml
+++ b/src/it/tests/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -48,7 +48,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.0.0-M7</version>
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <forkMode>once</forkMode>
@@ -79,7 +79,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.0.0-M7</version>
                     <configuration>
                         <skip>true</skip>
                     </configuration>

--- a/src/it/tests/update-server-from-xml-it/pom.xml
+++ b/src/it/tests/update-server-from-xml-it/pom.xml
@@ -16,7 +16,7 @@
 
     <profiles>
         <profile>
-            <id>online-test</id>
+            <id>online-test-unix</id>
             <build>
                 <plugins>
                     <plugin>
@@ -32,6 +32,31 @@
                                 <configuration>
                                     <target>
                                         <ant dir="${basedir}" antfile="${basedir}\build.xml" target="updateServer" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>online-test-windows</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>installFeatures</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\windows\build.xml" target="updateServer" />
                                     </target>
                                 </configuration>
                             </execution>

--- a/src/it/tests/update-server-from-xml-it/windows/build.xml
+++ b/src/it/tests/update-server-from-xml-it/windows/build.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<project xmlns:wlp="antlib:io.openliberty.tools.ant" name="net.wasdev.wlp.ant.it">
+
+    <path id="liberty-ant-tasks.classpath">
+        <fileset dir="${basedir}/../../../../target" includes="liberty-ant-tasks-*.jar" />
+    </path>
+    <typedef resource="io/openliberty/tools/ant/antlib.xml" uri="antlib:io.openliberty.tools.ant" classpathref="liberty-ant-tasks.classpath" />
+
+    <property name="target.dir" value="${basedir}/../install-server-it/target" />
+
+    <!-- Defining server configuration -->
+    <property name="wlp.install.dir" value="${target.dir}/wlp" />
+    <property name="wlp.usr.dir" value="${target.dir}/wlp_usr" />
+    <property name="wlp.output.dir" value="${target.dir}/wlp_output" />
+    <property name="servername" value="deploy.war" />
+
+    <property name="serverConfig" value="${basedir}/src/test/resources/server.xml" />
+    <property name="bootProp" value="${basedir}/src/test/resources/bootstrap.properties" />
+
+    <target name="updateServer">
+        <wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" operation="status" />
+
+        <copy overwrite="true" file="${serverConfig}" toFile="${wlp.usr.dir}/servers/${servername}/server.xml" />
+        <copy file="${bootProp}" toFile="${wlp.usr.dir}/servers/${servername}/bootstrap.properties" />
+		        
+        <!-- install the features from the server.xml file-->
+        <wlp:install-feature ref="testServer" acceptLicense="true" />
+    	
+    	<wlp:server operation="start" ref="testServer" />
+    	    	
+    	<wlp:server operation="stop" ref="testServer" />
+    	
+    </target>
+
+</project>


### PR DESCRIPTION
Update wlp versions and their licenses in yaml file.

Also made updates to enable running with Java 17, and removed some uninstall-feature related tests for Windows only since they were failing consistently due to file locking issues.