### PR TITLE
One fix for pom.xml for Windows and IT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,6 @@
         </profile>
         <profile>
             <id>windows-online-its</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Removed `<activation>` element for windows related profile that caused it to always run on Windows. That profile should only run when explicitly specified on the command line.