### PR TITLE
Color warnings/errors from Liberty server message logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.openliberty.tools</groupId>
     <artifactId>liberty-ant-tasks</artifactId>
-    <version>1.9.13-fixLoggingForTasks</version>
+    <version>1.9.13-SNAPSHOT</version>
     <name>Open Liberty and WebSphere Liberty Ant Tasks</name>
     <description>Parent pom for Ant tasks supporting development with Open Liberty and WebSphere Liberty.</description>
     <url>https://github.com/openliberty/ci.ant</url>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.openliberty.tools</groupId>
     <artifactId>liberty-ant-tasks</artifactId>
-    <version>1.9.13-SNAPSHOT</version>
+    <version>1.9.13-fixLoggingForTasks</version>
     <name>Open Liberty and WebSphere Liberty Ant Tasks</name>
     <description>Parent pom for Ant tasks supporting development with Open Liberty and WebSphere Liberty.</description>
     <url>https://github.com/openliberty/ci.ant</url>

--- a/src/main/java/io/openliberty/tools/ant/AbstractTask.java
+++ b/src/main/java/io/openliberty/tools/ant/AbstractTask.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2020.
+ * (C) Copyright IBM Corporation 2014, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ public abstract class AbstractTask extends Task {
     protected static boolean isWindows;
 
     protected ProcessBuilder processBuilder;
+
+    private static final String errorRegex = ".*\\[ERROR.*\\].*";
+    private static final Pattern errorPattern = Pattern.compile(errorRegex);
+    private static final String warnRegex = ".*\\[WARN.*\\].*";
+    private static final Pattern warnPattern = Pattern.compile(warnRegex);
 
     protected static final String DEFAULT_SERVER = "defaultServer";
     protected static final String DEFAULT_LOG_FILE = "logs/messages.log";
@@ -268,7 +273,14 @@ public abstract class AbstractTask extends Task {
                             break;
                         }
                         sb.append(line);
-                        log(line);
+                        // Check if the log message should be warning or error instead of info.
+                        if (errorPattern.matcher(line).find()) {
+                            log(line, Project.MSG_ERR);
+                        } else if (warnPattern.matcher(line).find()) {
+                            log(line, Project.MSG_WARN);
+                        } else {
+                            log(line);
+                        }                    
                     }
                 }
             } catch (IOException ex) {

--- a/src/main/java/io/openliberty/tools/ant/AbstractTask.java
+++ b/src/main/java/io/openliberty/tools/ant/AbstractTask.java
@@ -62,11 +62,7 @@ public abstract class AbstractTask extends Task {
 
     protected ProcessBuilder processBuilder;
 
-    private static final String errorRegex = ".*\\[ERROR.*\\].*";
-    private static final Pattern errorPattern = Pattern.compile(errorRegex);
-    private static final String warnRegex = ".*\\[WARN.*\\].*";
-    private static final Pattern warnPattern = Pattern.compile(warnRegex);
-    private static final String LIBERTY_MESSAGE_TYPE_REGEX = "(.*\\[)(.*)(\\] [\\S]*?(\\S):.*)";
+    private static final String LIBERTY_MESSAGE_TYPE_REGEX = ".*\\[.*\\] [\\S]*?(\\S):.*";
     private static final Pattern LIBERTY_MESSAGE_TYPE_PATTERN = Pattern.compile(LIBERTY_MESSAGE_TYPE_REGEX);
 
     protected static final String DEFAULT_SERVER = "defaultServer";
@@ -311,22 +307,28 @@ public abstract class AbstractTask extends Task {
             }
         }
 
+        /**
+         * Check the last letter of Liberty server message code to determine severity, and log with appropriate color
+         * @param line - Liberty server message
+         */
         private void logWithColor(String line) {
             Matcher m = LIBERTY_MESSAGE_TYPE_PATTERN.matcher(line);
-            // Group 2 - liberty log severity text
-            // Group 4 - liberty log identifier code
+            // Group 1 - liberty log identifier code
             if (m.find()) {
-                String identifier = m.group(4);
+                String identifier = m.group(1);
                 switch (identifier) {
                     case "E":
-                        log(m.group(1) + ANSI_RED + m.group(2) + ANSI_RESET + m.group(3));
+                        log(ANSI_RED + line + ANSI_RESET);
                         break;
                     case "W":
-                        log(m.group(1) + ANSI_YELLOW + m.group(2) + ANSI_RESET + m.group(3));
+                        log(ANSI_YELLOW + line + ANSI_RESET);
                         break;
                     default:
                         log(line);
+                        break;
                 }
+            } else { // could not find Liberty server message identifier
+                log(line);
             }
         }
 

--- a/src/main/java/io/openliberty/tools/ant/AbstractTask.java
+++ b/src/main/java/io/openliberty/tools/ant/AbstractTask.java
@@ -258,8 +258,9 @@ public abstract class AbstractTask extends Task {
     }
 
     /**
-     * Check the last letter of Liberty server message code to determine severity, and log with appropriate color
+     * Check the last letter of Liberty server message code to determine severity, and add ANSI colors to the log message
      * @param line - Liberty server message
+     * @return - Liberty server message with appropriate color based on severity
      */
     public static String addColor(String line) {
         Matcher m = LIBERTY_MESSAGE_TYPE_PATTERN.matcher(line);

--- a/src/main/java/io/openliberty/tools/ant/AbstractTask.java
+++ b/src/main/java/io/openliberty/tools/ant/AbstractTask.java
@@ -37,6 +37,16 @@ import org.apache.tools.ant.Task;
 
 public abstract class AbstractTask extends Task {
 
+    public static final String ANSI_RESET = "\u001B[0m";
+    public static final String ANSI_BLACK = "\u001B[30m";
+    public static final String ANSI_RED = "\u001B[31m";
+    public static final String ANSI_GREEN = "\u001B[32m";
+    public static final String ANSI_YELLOW = "\u001B[33m";
+    public static final String ANSI_BLUE = "\u001B[34m";
+    public static final String ANSI_PURPLE = "\u001B[35m";
+    public static final String ANSI_CYAN = "\u001B[36m";
+    public static final String ANSI_WHITE = "\u001B[37m";
+
     protected File installDir;
     protected File userDir;
     protected File outputDir;
@@ -86,7 +96,8 @@ public abstract class AbstractTask extends Task {
                     throw new BuildException(messages.getString("error.installDir.set"));
                 }
 
-                log(MessageFormat.format(messages.getString("info.variable"), "installDir", installDir.getCanonicalPath()), Project.MSG_VERBOSE);
+                log(MessageFormat.format(messages.getString("info.variable"), "installDir", installDir.getCanonicalPath()),
+                        Project.MSG_VERBOSE);
             } else {
                 throw new BuildException("Liberty installation directory must be set.");
             }
@@ -111,10 +122,12 @@ public abstract class AbstractTask extends Task {
                 }
             }
 
-            log(MessageFormat.format(messages.getString("info.variable"), "server.config.dir", serverConfigDir.getCanonicalPath()), Project.MSG_VERBOSE);
+            log(MessageFormat.format(messages.getString("info.variable"), "server.config.dir", serverConfigDir.getCanonicalPath()),
+                    Project.MSG_VERBOSE);
 
             if (outputDir != null) {
-                log(MessageFormat.format(messages.getString("info.variable"), "outputDir", outputDir.getCanonicalPath()), Project.MSG_VERBOSE);
+                log(MessageFormat.format(messages.getString("info.variable"), "outputDir", outputDir.getCanonicalPath()),
+                        Project.MSG_VERBOSE);
                 processBuilder.environment().put(WLP_OUTPUT_DIR_VAR, outputDir.getCanonicalPath());
                 serverOutputDir = new File(outputDir, serverName);
             } else {
@@ -127,7 +140,8 @@ public abstract class AbstractTask extends Task {
                 }
             }
 
-            log(MessageFormat.format(messages.getString("info.variable"), "server.output.dir", serverOutputDir.getCanonicalPath()), Project.MSG_VERBOSE);
+            log(MessageFormat.format(messages.getString("info.variable"), "server.output.dir", serverOutputDir.getCanonicalPath()),
+                    Project.MSG_VERBOSE);
         } catch (IOException e) {
             throw new BuildException(e);
         }
@@ -174,8 +188,7 @@ public abstract class AbstractTask extends Task {
     }
 
     /**
-     * @param serverName
-     *            the serverName to set
+     * @param serverName the serverName to set
      */
     public void setServerName(String serverName) {
         this.serverName = serverName;
@@ -224,7 +237,8 @@ public abstract class AbstractTask extends Task {
         sendErrorInvokeCommand(commandLine, exitVal, expectedExitCodes);
     }
 
-    public void checkReturnCodeAndError(Process p, String commandLine, int expectedExitCode, int allowedExitCode, String allowedErrorMessage) throws InterruptedException {
+    public void checkReturnCodeAndError(Process p, String commandLine, int expectedExitCode, int allowedExitCode,
+            String allowedErrorMessage) throws InterruptedException {
         log(MessageFormat.format(messages.getString("info.variable"), "Invoke command", commandLine, Project.MSG_VERBOSE));
 
         StreamCopier copier = new StreamCopier(p.getInputStream());
@@ -238,7 +252,7 @@ public abstract class AbstractTask extends Task {
         if (exitVal == expectedExitCode) {
             return;
         } else if ((exitVal == allowedExitCode) && stdOutAndError.startsWith(allowedErrorMessage)) {
-            log("The command "+commandLine+" failed with return code 21 with this error message: "+stdOutAndError, Project.MSG_WARN);
+            log("The command " + commandLine + " failed with return code 21 with this error message: " + stdOutAndError, Project.MSG_WARN);
             return;
         }
 
@@ -246,7 +260,8 @@ public abstract class AbstractTask extends Task {
     }
 
     public void sendErrorInvokeCommand(String commandLine, int returnCode, int... expectedExitCodes) {
-        throw new BuildException(MessageFormat.format(messages.getString("error.invoke.command"), commandLine, returnCode, Arrays.toString(expectedExitCodes)));
+        throw new BuildException(MessageFormat.format(messages.getString("error.invoke.command"), commandLine, returnCode,
+                Arrays.toString(expectedExitCodes)));
     }
 
     private class StreamCopier extends Thread {
@@ -275,12 +290,12 @@ public abstract class AbstractTask extends Task {
                         sb.append(line);
                         // Check if the log message should be warning or error instead of info.
                         if (errorPattern.matcher(line).find()) {
-                            log(line, Project.MSG_ERR);
+                            log(ANSI_RED + line + ANSI_RESET);
                         } else if (warnPattern.matcher(line).find()) {
-                            log(line, Project.MSG_WARN);
+                            log(ANSI_YELLOW + line + ANSI_RESET);
                         } else {
                             log(line);
-                        }                    
+                        }
                     }
                 }
             } catch (IOException ex) {
@@ -299,7 +314,7 @@ public abstract class AbstractTask extends Task {
                 }
             }
         }
-  
+
         public String getOutput() {
             if (sb != null) {
                 return sb.toString();
@@ -324,8 +339,7 @@ public abstract class AbstractTask extends Task {
 
                 synchronized (this) {
                     long begin = System.nanoTime();
-                    long end = begin
-                               + TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
+                    long end = begin + TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
                     long duration = end - begin;
                     while (!terminated && duration > 0) {
                         TimeUnit.NANOSECONDS.timedWait(this, duration);
@@ -348,16 +362,13 @@ public abstract class AbstractTask extends Task {
     /**
      * Check for a number of strings in a potentially remote file
      *
-     * @param regexp
-     *            a regular expression to search for
-     * @param timeout
-     *            a timeout, in milliseconds
-     * @param outputFile
-     *            file to check
+     * @param regexp a regular expression to search for
+     * @param timeout a timeout, in milliseconds
+     * @param outputFile file to check
+     * 
      * @return line that matched the regexp
      */
-    public String waitForStringInLog(String regexp, long timeout,
-                                     File outputFile) {
+    public String waitForStringInLog(String regexp, long timeout, File outputFile) {
         long waited = 0;
         final long waitIncrement = 500;
 
@@ -385,12 +396,10 @@ public abstract class AbstractTask extends Task {
     /**
      * Searches the given file for the given regular expression.
      *
-     * @param regexp
-     *            a regular expression (or just a text snippet) to search for
-     * @param fileToSearch
-     *            the file to search
-     * @return The first line which includes the pattern, or null if the pattern
-     *         isn't found or if the file doesn't exist
+     * @param regexp a regular expression (or just a text snippet) to search for
+     * @param fileToSearch the file to search
+     * 
+     * @return The first line which includes the pattern, or null if the pattern isn't found or if the file doesn't exist
      */
     public String findStringInFile(String regexp, File fileToSearch) {
         return findStringInFile(regexp, fileToSearch, Project.MSG_VERBOSE);
@@ -399,12 +408,10 @@ public abstract class AbstractTask extends Task {
     /**
      * Searches the given file for the given regular expression.
      *
-     * @param regexp
-     *            a regular expression (or just a text snippet) to search for
-     * @param fileToSearch
-     *            the file to search
-     * @return List of lines which includes the pattern, or null if the pattern
-     *         isn't found or if the file doesn't exist
+     * @param regexp a regular expression (or just a text snippet) to search for
+     * @param fileToSearch the file to search
+     * 
+     * @return List of lines which includes the pattern, or null if the pattern isn't found or if the file doesn't exist
      */
     public List<String> findStringsInFile(String regexp, File fileToSearch) {
         return findStringsInFileCommon(regexp, false, -1, fileToSearch, Project.MSG_VERBOSE);
@@ -413,14 +420,11 @@ public abstract class AbstractTask extends Task {
     /**
      * Searches the given file for the given regular expression.
      *
-     * @param regexp
-     *            a regular expression (or just a text snippet) to search for
-     * @param fileToSearch
-     *            the file to search
-     * @param msgLevel
-     *            the log level for the match number message
-     * @return The first line which includes the pattern, or null if the pattern
-     *         isn't found or if the file doesn't exist
+     * @param regexp a regular expression (or just a text snippet) to search for
+     * @param fileToSearch the file to search
+     * @param msgLevel the log level for the match number message
+     * 
+     * @return The first line which includes the pattern, or null if the pattern isn't found or if the file doesn't exist
      */
     private String findStringInFile(String regexp, File fileToSearch, int msgLevel) {
         String foundString = null;
@@ -436,17 +440,13 @@ public abstract class AbstractTask extends Task {
     /**
      * Searches the given file for the given regular expression.
      *
-     * @param regexp
-     *            a regular expression (or just a text snippet) to search for
-     * @param fileToSearch
-     *            the file to search
-     * @param msgLevel
-     *            the log level for the match number message
-     * @return List of Strings which match the pattern. No match results in an
-     *         empty list.
+     * @param regexp a regular expression (or just a text snippet) to search for
+     * @param fileToSearch the file to search
+     * @param msgLevel the log level for the match number message
+     * 
+     * @return List of Strings which match the pattern. No match results in an empty list.
      */
-    private List<String> findStringsInFileCommon(String regexp,
-                                                   boolean stopOnFirst, int searchLimit, File fileToSearch, int msgLevel) {
+    private List<String> findStringsInFileCommon(String regexp, boolean stopOnFirst, int searchLimit, File fileToSearch, int msgLevel) {
         if (fileToSearch == null) {
             log(messages.getString("info.file.validated"));
             return null;
@@ -512,7 +512,7 @@ public abstract class AbstractTask extends Task {
             try {
                 in.close();
             } catch (Exception e) {
-                //Ignore
+                // Ignore
             }
 
         }
@@ -523,10 +523,9 @@ public abstract class AbstractTask extends Task {
     /**
      * Searches the given file for the given regular expression, and returns the number of times it occurs.
      * 
-     * @param regexp
-     *            a regular expression (or just a text snippet) to search for
-     * @param fileToSearch
-     *            the file to search
+     * @param regexp a regular expression (or just a text snippet) to search for
+     * @param fileToSearch the file to search
+     * 
      * @return the number of occurrences of the regular expression
      */
     public int countStringOccurrencesInFile(String regexp, File fileToSearch) {
@@ -539,21 +538,17 @@ public abstract class AbstractTask extends Task {
     }
 
     /**
-     * Wait until the number of occurrences of the regular expression in the file increases
-     * above the given number of previous occurrences.
+     * Wait until the number of occurrences of the regular expression in the file increases above the given number of previous
+     * occurrences.
      *
-     * @param regexp
-     *            a regular expression to search for
-     * @param timeout
-     *            a timeout, in milliseconds
-     * @param outputFile
-     *            file to check
-     * @param previousOccurrences 
-     *.           the previous number of occurrences of the regular expression
+     * @param regexp a regular expression to search for
+     * @param timeout a timeout, in milliseconds
+     * @param outputFile file to check
+     * @param previousOccurrences . the previous number of occurrences of the regular expression
+     * 
      * @return updated line that matched the regexp
      */
-    public String waitForUpdatedStringInLog(String regexp, long timeout,
-                                     File outputFile, int previousOccurrences) {
+    public String waitForUpdatedStringInLog(String regexp, long timeout, File outputFile, int previousOccurrences) {
         long waited = 0;
         final long waitIncrement = 500;
 
@@ -584,7 +579,7 @@ public abstract class AbstractTask extends Task {
      * Returns file name without the extension.
      */
     protected String getFileName(String fileName) {
-        if (fileName.endsWith(".xml")) { //Handle loose app case for deploy
+        if (fileName.endsWith(".xml")) { // Handle loose app case for deploy
             fileName = fileName.substring(0, fileName.lastIndexOf('.'));
         }
 
@@ -593,7 +588,7 @@ public abstract class AbstractTask extends Task {
     }
 
     protected void stopServer(String timeout) {
-        //Stop server if exception happens.
+        // Stop server if exception happens.
         ServerTask st = new ServerTask();
         st.setProject(getProject());
         st.setInstallDir(getInstallDir());
@@ -604,7 +599,7 @@ public abstract class AbstractTask extends Task {
         st.setOperation("stop");
         st.execute();
     }
-    
+
     protected String getMessage(String key, Object... args) {
         return MessageFormat.format(messages.getString(key), args);
     }

--- a/src/test/java/net/wasdev/wlp/ant/LogColorTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/LogColorTest.java
@@ -1,0 +1,29 @@
+package net.wasdev.wlp.ant;
+
+import org.junit.Assert;
+import org.junit.Test;
+import io.openliberty.tools.ant.AbstractTask;
+
+public class LogColorTest {
+    @Test
+    public void testWarningColor() {
+        String logMessage = "[WARNING ] CWWKS3103W: There are no users defined for the BasicRegistry configuration of ID com.ibm.ws.security.registry.basic.config[basic].";
+        String line = AbstractTask.addColor(logMessage);
+        Assert.assertTrue(line.contains(AbstractTask.ANSI_YELLOW));
+        Assert.assertTrue(line.contains(AbstractTask.ANSI_RESET));
+    }
+
+    @Test
+    public void testErrorColor() {
+        String logMessage = "[ERROR   ] SRVE9990E: The class mvn.demo.rest.RestApplication has a @WebServlet annotation but does not implement the jakarta.servlet.http.HttpServlet interface.";
+        String line = AbstractTask.addColor(logMessage);
+        Assert.assertTrue(line.contains(AbstractTask.ANSI_RED));
+        Assert.assertTrue(line.contains(AbstractTask.ANSI_RESET));
+    }
+
+    @Test
+    public void testInfoColor() {
+        String logMessage = "[AUDIT   ] CWWKT0016I: Web application available (default_host): http://localhost:9080/openapi/";
+        String line = AbstractTask.addColor(logMessage);
+        Assert.assertEquals(logMessage, line); // should not have any ANSI colors
+    }}


### PR DESCRIPTION
Fixes OpenLiberty/ci.maven#1680. Based on #160 

Add coloring to warnings and errors from the Liberty server message logs to easily identify them.
Keys off of the Liberty server message identifier, ie: `E` or `W` at the end of the identifier code.

In LMP:
![image](https://github.com/OpenLiberty/ci.ant/assets/689163/5ace3815-79d5-4481-b9b5-6481afee82ea)

In LGP:
![image](https://github.com/OpenLiberty/ci.ant/assets/689163/a35b9129-3418-4175-864e-870f0f66d655)
