### PR TITLE
Fix build timeout errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,28 +82,31 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.6.0</version>
-                    <configuration>
-                        <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>integration-test</id>
-                            <goals>
-                                <goal>install</goal>
-                                <goal>run</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>

--- a/src/it/tests/deploy-eba-it/windows/build.xml
+++ b/src/it/tests/deploy-eba-it/windows/build.xml
@@ -33,7 +33,7 @@
 
         <wlp:server ref="testServer" operation="stop" />
 
-        <wlp:clean ref="testServer" apps="true" dropins="true" />
+        <wlp:clean ref="testServer" apps="true" dropins="true" logs="false" workarea="false" />
     	
     </target>
 	

--- a/src/main/java/io/openliberty/tools/ant/install/ArchiveInstaller.java
+++ b/src/main/java/io/openliberty/tools/ant/install/ArchiveInstaller.java
@@ -82,7 +82,7 @@ public class ArchiveInstaller implements Installer {
             task.checkLicenseSet();
 
             // download Liberty jar
-            task.downloadFile(downloadURL, cachedFile);
+            task.downloadFile(downloadURL, cachedFile, true);
 
             // do license check
             task.checkLicense(getLicenseCode(cachedFile));
@@ -91,7 +91,7 @@ public class ArchiveInstaller implements Installer {
             task.installLiberty(cachedFile);
         } else {
             // download zip file
-            task.downloadFile(downloadURL, cachedFile);
+            task.downloadFile(downloadURL, cachedFile, true);
 
             // unzip
             task.unzipLiberty(cachedFile);

--- a/src/main/java/io/openliberty/tools/ant/install/InstallLibertyTask.java
+++ b/src/main/java/io/openliberty/tools/ant/install/InstallLibertyTask.java
@@ -98,10 +98,14 @@ public class InstallLibertyTask extends AbstractTask {
     }
 
     protected void downloadFile(URL source, File dest) throws IOException {
+        downloadFile(source, dest, false);
+    }
+
+    protected void downloadFile(URL source, File dest, boolean skipExisting) throws IOException {
         if (offline) {
             offlineDownload(source, dest);
         } else {
-            onlineDownload(source, dest);
+            onlineDownload(source, dest, skipExisting);
         }
     }
 
@@ -113,13 +117,15 @@ public class InstallLibertyTask extends AbstractTask {
         }
     }
 
-    private void onlineDownload(URL source, File dest) throws IOException {
+    private void onlineDownload(URL source, File dest, boolean skipExisting) throws IOException {
         Get get = (Get) getProject().createTask("get");
         DownloadProgress progress = null;
         if (verbose) {
             progress = new Get.VerboseProgress(System.out);
         }
-        get.setUseTimestamp(true);
+        if (skipExisting) {
+            get.setSkipExisting(true);
+        }
         get.setUsername(username);
         get.setPassword(password);
         get.setMaxTime(maxDownloadTime);

--- a/src/main/java/io/openliberty/tools/ant/install/OpenLibertyInstaller.java
+++ b/src/main/java/io/openliberty/tools/ant/install/OpenLibertyInstaller.java
@@ -53,7 +53,7 @@ public class OpenLibertyInstaller implements Installer {
         String versionUrl = baseUrl + version + "/";
         URL runtimeInfoUrl = new URL(versionUrl + "info.json");
         File runtimeInfoFile = new File(cacheDir, version + ".json");
-        task.downloadFile(runtimeInfoUrl, runtimeInfoFile);
+        task.downloadFile(runtimeInfoUrl, runtimeInfoFile, true);
         
         // Parse JSON
         InputStream runtimeInfoIs =  new FileInputStream(runtimeInfoFile);
@@ -93,7 +93,7 @@ public class OpenLibertyInstaller implements Installer {
         
         URL runtimeUrl = new URL(runtimeUrlString);
         File runtimeFile = new File(versionCacheDir, InstallUtils.getFile(runtimeUrl));
-        task.downloadFile(runtimeUrl, runtimeFile);
+        task.downloadFile(runtimeUrl, runtimeFile, true);
                 
         if(runtimeUrlString.endsWith(".jar")) {
             task.installLiberty(runtimeFile);

--- a/src/main/java/io/openliberty/tools/ant/install/WasDevInstaller.java
+++ b/src/main/java/io/openliberty/tools/ant/install/WasDevInstaller.java
@@ -103,7 +103,7 @@ public class WasDevInstaller implements Installer {
             // download license
             URL licenseURL = new URL(selectedVersion.getLicenseUri());
             File licenseFile = new File(versionCacheDir, InstallUtils.getFile(licenseURL));
-            task.downloadFile(licenseURL, licenseFile);
+            task.downloadFile(licenseURL, licenseFile, true);
 
             // do license check
             task.checkLicense(InstallUtils.getLicenseCode(licenseFile, LICENSE_REGEX));
@@ -111,7 +111,7 @@ public class WasDevInstaller implements Installer {
             // download Liberty jar
             URL libertyURL = new URL(uri);
             File libertyFile = new File(versionCacheDir, InstallUtils.getFile(libertyURL));
-            task.downloadFile(libertyURL, libertyFile);
+            task.downloadFile(libertyURL, libertyFile, true);
 
             // install Liberty jar
             task.installLiberty(libertyFile);
@@ -119,7 +119,7 @@ public class WasDevInstaller implements Installer {
             // download zip file
             URL libertyURL = new URL(uri);
             File libertyFile = new File(versionCacheDir, InstallUtils.getFile(libertyURL));
-            task.downloadFile(libertyURL, libertyFile);
+            task.downloadFile(libertyURL, libertyFile, true);
 
             // unzip
             task.unzipLiberty(libertyFile);


### PR DESCRIPTION
For files that the content does not change, set the `skipExisting` parameter to `true` so that they are not redownloaded. Still need to get the `index.yml` file and `openliberty-versions.json` file every time, since new versions are added regularly.